### PR TITLE
Added getAll endpoint with its tests for EscapePod

### DIFF
--- a/src/controllers/EscapePodController.test.ts
+++ b/src/controllers/EscapePodController.test.ts
@@ -24,6 +24,51 @@ describe(
     afterEach(() => sandbox.restore());
 
     it(
+      "getAll should return 200 and get a list of all escapePods", async () => {
+
+        // Given
+        const escapePodsMock = [ getEscapePodMock(), getEscapePodMock(), getEscapePodMock() ];
+        const fakeService = sinon.createStubInstance(EscapePodService);
+        const fakeReq = getRequestMock();
+        const fakeRes = getResponseMock();
+        const controller = new EscapePodController(fakeService);
+
+        // When
+        fakeService.getAll.resolves(escapePodsMock);
+
+        await controller.getAll(
+          fakeReq, fakeRes as any, null,
+        );
+
+        // Then
+        expect(fakeService.getAll.called).toBeTruthy();
+        expect(fakeRes.json.calledOnceWithExactly({
+          data: escapePodsMock,
+        })).toBeTruthy();
+        expect(fakeRes.status.calledOnceWithExactly(200)).toBeTruthy();
+      },
+    );
+
+    it(
+      "getAll should bubble up exception", async () => {
+        // Given
+        const fakeService = sinon.createStubInstance(EscapePodService);
+        const fakeReq = getRequestMock();
+        const fakeRes = getResponseMock();
+        const controller = new EscapePodController(fakeService);
+
+        // When
+        fakeService.getAll.throws();
+
+        // Then
+        await expect(controller.getAll(
+          fakeReq, fakeRes as any, null,
+        )).rejects.toThrow();
+        expect(fakeService.getAll.calledOnce).toBeTruthy();
+      },
+    );
+
+    it(
       "getById should return 200 and escapePod on success and found escapePod", async () => {
         // Given
         const escapePodMock = getEscapePodMock();

--- a/src/controllers/EscapePodController.ts
+++ b/src/controllers/EscapePodController.ts
@@ -24,6 +24,15 @@ class EscapePodController implements IController {
 
   protected readonly escapePodMapper;
 
+  public getAll: IRequestHandler = async (
+    req, res,
+  ) => {
+    const escapePods = await this.escapePodService.getAll();
+
+    res.status(200).json({
+      data: escapePods,
+    });
+  };
 
   public getById: IRequestHandler = async (
     req, res,

--- a/src/routes/EscapePodRouter.ts
+++ b/src/routes/EscapePodRouter.ts
@@ -27,6 +27,10 @@ class EscapePodRouter implements IRouter {
 
   initializeRoutes() {
 
+    this.router.get(
+      `${this.path}`,
+      this.escapePodController.getAll,
+    );
 
     this.router.get(
       `${this.path}/:id(\\d+)`,

--- a/src/services/EscapePodService.test.ts
+++ b/src/services/EscapePodService.test.ts
@@ -17,6 +17,26 @@ describe(
 
 
     it(
+      "getAll should return an array of all escapePods when called", async () => {
+        // Given
+        const escapePodsMock = [ getEscapePodMock(), getEscapePodMock(), getEscapePodMock() ];
+        const fakeRepo = stubInterface<IRepository<EscapePod>>();
+
+        // When
+        fakeRepo.find.resolves(escapePodsMock);
+        sandbox.replace(
+          EscapePodService.prototype, "getRepository", () => fakeRepo,
+        );
+
+        const res = await new EscapePodService().getAll();
+
+        // Then
+        expect(fakeRepo.find.called).toBeTruthy();
+        expect(res).toEqual(escapePodsMock);
+      },
+    );
+
+    it(
       "getById success", async () => {
         // Given
         const escapePodMock = getEscapePodMock();

--- a/src/services/EscapePodService.ts
+++ b/src/services/EscapePodService.ts
@@ -5,18 +5,11 @@ import { IService } from "../types/IService";
 import EscapePod from "../entities/EscapePod";
 import EscapePodCreateBodyValidator from "../validators/EscapePod/EscapePodCreateBodyValidator";
 import IRepository from "../types/IRepository";
-import NotImplementedException from "../exceptions/NotImplementedException";
 import EscapePodUpdateBodyValidator from "../validators/EscapePod/EscapePodUpdateBodyValidator";
 import NotFoundException from "../exceptions/NotFoundException";
 
 
 export default class EscapePodService implements IService<EscapePod> {
-  getAll(): Promise<EscapePod[]> {
-    throw new NotImplementedException();
-  }
-
-
-
 
   public getRepository(): IRepository<EscapePod> {
     return escapePodRepository();
@@ -32,6 +25,11 @@ export default class EscapePodService implements IService<EscapePod> {
     key: string, value: string | number,
   ) => `EscapePod ${key}:${value} not found`;
 
+  public async getAll(): Promise<EscapePod[]> {
+    const escapePods = await this.getRepository().find();
+
+    return escapePods;
+  }
 
   public async getByKey(
     key: string, val: string | number,


### PR DESCRIPTION
# Pull Request

## Type of Change

- New feature (non-breaking change which adds functionality)

## Branch information

* **Resolves**: #Get all escape pods
* **Description** An endpoint for getting all escape pods of the application was added. Unit testing was also developed for it.

## Checklist

* [X] Adds new tests
* [X] New and existing test suites succeed
* [X] Linter succeeds
* [?] Updates corresponding documentation