### PR TITLE
Fixed return interface of getAll escape pods

### DIFF
--- a/src/controllers/EscapePodController.test.ts
+++ b/src/controllers/EscapePodController.test.ts
@@ -43,7 +43,7 @@ describe(
         // Then
         expect(fakeService.getAll.called).toBeTruthy();
         expect(fakeRes.json.calledOnceWithExactly({
-          data: escapePodsMock,
+          data: escapePodsMock.map((escapePod) => new EscapePodMapper().toDto(escapePod)),
         })).toBeTruthy();
         expect(fakeRes.status.calledOnceWithExactly(200)).toBeTruthy();
       },

--- a/src/controllers/EscapePodController.ts
+++ b/src/controllers/EscapePodController.ts
@@ -30,7 +30,7 @@ class EscapePodController implements IController {
     const escapePods = await this.escapePodService.getAll();
 
     res.status(200).json({
-      data: escapePods,
+      data: escapePods.map((escapedPod) => this.escapePodMapper.toDto(escapedPod)),
     });
   };
 


### PR DESCRIPTION
# Pull Request

## Type of Change

    - Bug fix (non-breaking change which fixes an issue)

## Branch information

* **Description** As discussed with Nacho, we need to have a set of standard interfaces to return non-breaking information to the client. With that in mind, I implemented inside of the "getAll" controller the "toDto" method from the mapper in order to achieve this goal.

## Checklist

* [X] Adds new tests
* [X] New and existing test suites succeed
* [X] Linter succeeds
* [?] Updates corresponding documentation